### PR TITLE
fixed long description on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(name='dask-lightgbm',
       long_description=(io.open('README.md', encoding='utf-8').read()
                         if os.path.exists('README.md')
                         else ''),
+      long_description_content_type='text/markdown',
       license='BSD',
       url='https://github.com/dask/dask-lightgbm',
       install_requires=install_requires,


### PR DESCRIPTION
Hotfix for 07534b1c39dce7653108fc6892d1c69497b2f0e9.

Refer to https://github.com/pypa/packaging-problems/issues/46, https://stackoverflow.com/a/26737258, https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi.