### PR TITLE
Update to recent versions of libraries

### DIFF
--- a/dask_lightgbm/core.py
+++ b/dask_lightgbm/core.py
@@ -144,7 +144,7 @@ def _predict_part(part, model, proba, **kwargs):
     else:
         X = part
     if not X.shape[0]:
-        result = []
+        result = np.array([])
     elif proba:
         result = model.predict_proba(X, **kwargs)
     else:

--- a/dask_lightgbm/core.py
+++ b/dask_lightgbm/core.py
@@ -32,12 +32,12 @@ def parse_host_port(address):
     return host, port
 
 
-def build_network_params(worker_addresses, local_worker_ip, local_listen_port, listen_time_out):
+def build_network_params(worker_addresses, local_worker_ip, local_listen_port, time_out):
     addr_port_map = {addr: (local_listen_port + i) for i, addr in enumerate(worker_addresses)}
     params = {
         "machines": ",".join([parse_host_port(addr)[0] + ":" + str(port) for addr, port in addr_port_map.items()]),
         "local_listen_port": addr_port_map[local_worker_ip],
-        "listen_time_out": listen_time_out,
+        "time_out": time_out,
         "num_machines": len(addr_port_map)
     }
     return params
@@ -56,10 +56,8 @@ def concat(L):
         raise TypeError("Data must be either numpy arrays or pandas dataframes. Got %s" % type(L[0]))
 
 
-def _fit_local(params, model_factory, list_of_parts, worker_addresses, return_model, local_listen_port=12400, listen_time_out=120,
-               **kwargs):
-    network_params = build_network_params(worker_addresses, get_worker().address, local_listen_port,
-                                          listen_time_out)
+def _fit_local(params, model_factory, list_of_parts, worker_addresses, return_model, local_listen_port=12400, time_out=120, **kwargs):
+    network_params = build_network_params(worker_addresses, get_worker().address, local_listen_port, time_out)
     params = {**params, **network_params}
 
     # Prepare data
@@ -127,7 +125,7 @@ def train(client, X, y, params, model_factory, sample_weight=None, **kwargs):
                                          list_of_parts=list_of_parts,
                                          worker_addresses=list(worker_map.keys()),
                                          local_listen_port=params.get("local_listen_port", 12400),
-                                         listen_time_out=params.get("listen_time_out", 120),
+                                         time_out=params.get("time_out", 120),
                                          return_model=worker==master_worker,
                                          **kwargs)
                            for worker, list_of_parts in worker_map.items()]

--- a/dask_lightgbm/core.py
+++ b/dask_lightgbm/core.py
@@ -207,13 +207,13 @@ class LGBMClassifier(lightgbm.LGBMClassifier):
     def predict(self, X, client=None, **kwargs):
         if client is None:
             client = default_client()
-        return predict(client, self.to_local(), X, dtype=self.classes_[0].dtype, **kwargs)
+        return predict(client, self.to_local(), X, dtype=self.classes_.dtype, **kwargs)
     predict.__doc__ = lightgbm.LGBMClassifier.predict.__doc__
 
     def predict_proba(self, X, client=None, **kwargs):
         if client is None:
             client = default_client()
-        return predict(client, self.to_local(), X, proba=True, dtype=self.classes_[0].dtype, **kwargs)
+        return predict(client, self.to_local(), X, proba=True, **kwargs)
     predict_proba.__doc__ = lightgbm.LGBMClassifier.predict_proba.__doc__
 
     def to_local(self):

--- a/dask_lightgbm/tests/test_core.py
+++ b/dask_lightgbm/tests/test_core.py
@@ -214,7 +214,7 @@ def test_build_network_params():
     assert exp_params == params
 
 
-@gen_cluster(client=True, timeout=None, check_new_threads=False)
+@gen_cluster(client=True, timeout=None)
 def test_errors(c, s, a, b):
     def f(part):
         raise Exception('foo')

--- a/dask_lightgbm/tests/test_core.py
+++ b/dask_lightgbm/tests/test_core.py
@@ -209,7 +209,7 @@ def test_build_network_params():
         "machines": "192.168.0.1:12400,192.168.0.2:12401,192.168.0.3:12402",
         "local_listen_port": 12401,
         "num_machines": len(workers_ips),
-        "listen_time_out": 120
+        "time_out": 120
     }
     assert exp_params == params
 

--- a/setup.py
+++ b/setup.py
@@ -5,24 +5,24 @@ import os
 from setuptools import setup
 
 install_requires = [
-    'numpy>=0.14.0',
-    'lightgbm>=2.2.2',
-    'dask>=0.16.0',
-    'distributed>=2.2.0'
+    'numpy>=1.17.3',
+    'lightgbm>=2.3.0',
+    'dask>=2.6.0',
+    'distributed>=2.6.0'
 ]
 
 extras_require = {
-    "dev": [
-        "pytest>=3.9.0",
-        "pandas>=0.23.0",
+    'dev': [
+        'pytest>=5.2.2',
+        'pandas>=0.25.3',
         'dask[dataframe]',
-        'dask-ml',
-        'requests',
-        'fsspec>=0.5.1'
+        'dask-ml>=1.1.1',
+        'requests>=2.22.0',
+        'fsspec>=0.5.2'
     ],
-    "sparse": [
-        "sparse==0.5.0",
-        "scipy>=1.0.0"
+    'sparse': [
+        'sparse==0.5.0',
+        'scipy>=1.3.1'
     ]
 }
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_requires = [
     'numpy>=0.14.0',
     'lightgbm>=2.2.2',
     'dask>=0.16.0',
-    'distributed>=1.15.2'
+    'distributed>=2.2.0'
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ extras_require = {
         "pandas>=0.23.0",
         'dask[dataframe]',
         'dask-ml',
-        'requests'
+        'requests',
+        'fsspec>=0.5.1'
     ],
     "sparse": [
         "sparse==0.5.0",

--- a/system_tests/test_fit_predict.py
+++ b/system_tests/test_fit_predict.py
@@ -9,7 +9,8 @@ import dask_lightgbm.core as dlgbm
 
 @pytest.fixture(scope='module')
 def client():
-    return Client(os.getenv('SCHEDULER')) if os.getenv('SCHEDULER') else Client()
+    with Client(os.getenv('SCHEDULER')) as client:
+        yield client
 
 
 @pytest.fixture()


### PR DESCRIPTION
I have made several updates to make dask-lightgbm working with the recent versions of Dask and LightGBM, for which the tests were failing. I have also fixed several bugs that seem not to be related to any specific version of Dask or LightGBM, e.g. 6527cdf or aa179ea.