### PR TITLE
Added kwargs to be passed to fit method

### DIFF
--- a/dask_lightgbm/core.py
+++ b/dask_lightgbm/core.py
@@ -68,7 +68,7 @@ def _train_part(params, model_factory, list_of_parts, worker_addresses, return_m
 
     try:
         model = model_factory(**params)
-        model.fit(data, label, sample_weight=weight)
+        model.fit(data, label, sample_weight=weight, **kwargs)
     finally:
         _safe_call(_LIB.LGBM_NetworkFree())
 


### PR DESCRIPTION
We want to be able to use early stopping in LightGBM. This requires us to pass evaluation set and stopping condition to LightGBM fit method. Currently kwargs are being sent through to train but they are not used. I am proposing to pass them to fit method in order to for example do the following:
```
x_eval_future = client.scatter(x_eval, broadcast=True)
y_eval_future = client.scatter(y_eval, broadcast=True)
d_regress = dlgbm.LGBMRegressor(**default_params())
d_regress.fit(x_train, y_train, eval_set=[(x_eval_future, y_eval_future)], early_stopping_rounds=20, verbose=200)
```