### PR TITLE
Ranker support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     hostname: dask-worker
     environment:
       - SCHEDULER=tcp://scheduler:8786
-    command: ["dask-worker", "--nprocs", "2", "--nthreads", "2", "scheduler:8786"]
+    command: ["dask-worker", "--nprocs", "2", "--nthreads", "2", "--memory-limit", "1e9", "scheduler:8786"]
 
   client:
     image: "dask-lightgbm:${DOCKER_TAG}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     hostname: dask-worker
     environment:
       - SCHEDULER=tcp://scheduler:8786
-    command: ["dask-worker", "--nprocs", "2", "--nthreads", "2", "--memory-limit", "1e9", "scheduler:8786"]
+    command: ["dask-worker", "--nprocs", "2", "--nthreads", "2", "--memory-limit", "2e9", "scheduler:8786"]
 
   client:
     image: "dask-lightgbm:${DOCKER_TAG}"


### PR DESCRIPTION
Hello Dask-lightgbm maintainers,

Thanks so much for creating a distributed version of LightGBM for Dask. Hey I'm hoping you might be open to this contribution - support for `LGBMRanker`.

The main difference between `LGBMClassifier` and `LGBMRegressor` is that ranking data is grouped via the `group` data parameter. Given this requirement, I could only write LGBMRanker to work with Dask DataFrames, because you can create partitions to accommodate grouped data with `dd.set_index`, so that grouped rows are not broken up and distributed to different workers. But I'm hoping you may also still find it useful to have ranker support, even if limited to Dask DataFrames.
