### PR TITLE
warn that dask-lightgbm is deprecated

### DIFF
--- a/dask_lightgbm/core.py
+++ b/dask_lightgbm/core.py
@@ -7,6 +7,7 @@ import dask.dataframe as dd
 import lightgbm
 import numpy as np
 import pandas as pd
+import warnings
 from dask import delayed
 from dask.distributed import wait, default_client, get_worker
 from lightgbm.basic import _safe_call, _LIB
@@ -22,6 +23,13 @@ except ImportError:
     ss = False
 
 logger = logging.getLogger(__name__)
+
+msg = (
+    "You are using the final release of dask-lightgbm. "
+    "dask-lightgbm functionality has been merged into lightgbm. "
+    "Consider switching to lightgbm."
+)
+warnings.warn(msg)
 
 
 def parse_host_port(address):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dask-lightgbm"
-version = "0.2.0.dev0"
+version = "0.3.0"
 description = "LightGBM distributed training on Dask"
 authors = [
     "Jan Stiborek <honza.stiborek@gmail.com>"


### PR DESCRIPTION
Based on my proposal in https://github.com/dask/dask-lightgbm/issues/29#issuecomment-775213120, I'd like to propose that `dask-lightgbm` have one more release, and that that release raise a warning on import informing users that the project is deprecated and that it has been merged into `lightgbm`.

I think this is preferable to just archiving the repo, because it means anyone upgrading `dask-lightgbm` in automation `pip install`-ing it based on a Stack Overflow answer or blog post will get a warning nudging them towards `lightgbm`.

As of the changes in this PR, the following warning will be shown once per session, when you import this library.

`python -c "import dask_lightgbm"`

> /Users/jlamb/repos/dask-lightgbm/dask_lightgbm/core.py:32: UserWarning: You are using the final release of dask-lightgbm. dask-lightgbm functionality has been merged into lightgbm. Consider switching to lightgbm.

cc @jsignell @jrbourbeau 

Thanks for your time and consideration.